### PR TITLE
chore: allow passing custom url

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -211,9 +211,10 @@ export class AppService {
     chain: string;
     gatewayAddress: string;
     txRequest: TransactionRequest;
+    rpcUrl?: string;
   }): Promise<{ data: ethers.providers.TransactionResponse }> {
-    const { chain, gatewayAddress, txRequest } = dto;
-    const data = await this.evmSigningClient.sendTx(chain, gatewayAddress, txRequest);
+    const { chain, gatewayAddress, txRequest, rpcUrl } = dto;
+    const data = await this.evmSigningClient.sendTx(chain, gatewayAddress, txRequest, rpcUrl);
     return {
       data,
     };

--- a/src/evm-signer.service.ts
+++ b/src/evm-signer.service.ts
@@ -37,9 +37,10 @@ export class EvmSigningClientUtil {
     chain: string,
     gatewayAddress: string,
     opts: TransactionRequest,
+    customRpcUrl?: string,
   ): Promise<ethers.providers.TransactionResponse> {
     const { maxFeePerGas, maxPriorityFeePerGas } = opts;
-    const rpcUrl = getRpcMap(this.env)[chain.toLowerCase()];
+    const rpcUrl = customRpcUrl || getRpcMap(this.env)[chain.toLowerCase()];
     const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
     const evm_mnemonic = this.config.get('EVM_MNEMONIC');
     this.signer = ethers.Wallet.fromMnemonic(evm_mnemonic).connect(provider);


### PR DESCRIPTION
# Description

Currently, I believe the `send_evm_tx` endpoint doesn't work for most chains since it used the hardcoded rpc endpoints which we haven't updated it for awhile, so there're only [5 chains](https://github.com/axelarnetwork/axelar-signing-relayer/blob/main/src/config/rpcMap.ts) that have rpc endpoints. 

This PR allows the client to pass custom `rpcUrl` to the endpoint, so we can avoid maintaining hardcoded rpc endpoints in this project or having to fetch rpc endpoints from remote locations.